### PR TITLE
Uncomment rsvg-sys path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ version = "0.2.0"
 features = ["png"]
 
 [dependencies.rsvg-sys]
-# path = "./rsvg-sys"
 version = "0.4.0"
+path = "./rsvg-sys"


### PR DESCRIPTION
A small trick I recently learned about: If both `version` and `path` are given, then `path` is tried first. If it does not exist the published version is used.