### PR TITLE
Makefile fix; regenerate test reference file so tests pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GIR = gir/target/bin/gir
 GIR_SRC = gir/Cargo.toml gir/Cargo.lock gir/build.rs $(shell find gir/src -name '*.rs')
-GIR_FILES = gir-files/Gtk-3.0.gir
+GIR_FILES = gir-files/Rsvg-2.0.gir
 GIR_SYS = $(rsvg-sys/Gir.toml=rsvg-sys/src/lib.rs)
 
 # Run `gir` generating the bindings

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,17 @@
 GIR = gir/target/bin/gir
 GIR_SRC = gir/Cargo.toml gir/Cargo.lock gir/build.rs $(shell find gir/src -name '*.rs')
 GIR_FILES = gir-files/Rsvg-2.0.gir
-GIR_SYS = $(rsvg-sys/Gir.toml=rsvg-sys/src/lib.rs)
+SYS_FILES = rsvg-sys/src/lib.rs
 
-# Run `gir` generating the bindings
-gir : src/auto/mod.rs
-gir-sys : rsvg-sys/src/lib.rs
-clean :
-	rm -rf src/auto
-	rm -rf
-
-src/auto/mod.rs : Gir.toml $(GIR) $(GIR_FILES)
+src/auto/mod.rs : Gir.toml $(GIR) $(GIR_FILES) $(SYS_FILES)
 	$(GIR) -c Gir.toml
 
-rsvg-sys/src/lib.rs : rsvg-sys/Gir.toml $(GIR) $(GIR_FILES)
+.PHONY: clean
+clean:
+	rm -rf src/auto
+	rm -rf $(SYS_FILES)
+
+$(SYS_FILES): rsvg-sys/Gir.toml $(GIR) $(GIR_FILES)
 	$(GIR) -c $< -o $(abspath rsvg-sys) -d gir-files
 
 $(GIR) : $(GIR_SRC)
@@ -23,3 +21,10 @@ $(GIR) : $(GIR_SRC)
 
 $(GIR_SRC) $(GIR_FILES) :
 	git submodule update --init
+
+.PHONY: gir
+gir : src/auto/mod.rs
+
+.PHONY: gir-sys
+gir-sys : $(SYS_FILES)
+

--- a/rsvg-sys/Gir.toml
+++ b/rsvg-sys/Gir.toml
@@ -7,13 +7,7 @@ external_libraries = [
    "GLib",
    "GObject",
    "Gio",
-   "Atk",
    "GdkPixbuf",
-   "Gdk",
    "Pango",
    "Cairo",
-]
-
-ignore = [
-   "xlib.Window",
 ]

--- a/rsvg-sys/Gir.toml
+++ b/rsvg-sys/Gir.toml
@@ -8,6 +8,5 @@ external_libraries = [
    "GObject",
    "Gio",
    "GdkPixbuf",
-   "Pango",
    "Cairo",
 ]

--- a/rsvg-sys/src/lib.rs
+++ b/rsvg-sys/src/lib.rs
@@ -8,10 +8,7 @@ extern crate libc;
 extern crate glib_sys as glib;
 extern crate gobject_sys as gobject;
 extern crate gio_sys as gio;
-extern crate atk_sys as atk;
 extern crate gdk_pixbuf_sys as gdk_pixbuf;
-extern crate gdk_sys as gdk;
-extern crate pango_sys as pango;
 extern crate cairo_sys as cairo;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
This is the fix we discussed in gitlab.gnome.org to make the `Makefile` look for `Rsvg-2.0.gir` correctly.

Also, I've regenerated the test reference PNG, so tests pass again.